### PR TITLE
allowing test suite to succeed when run as root

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,8 @@
 
+2016-05-13 Martin A. Brown <martin@linux-ip.net>
+  * bumping version to tldp-0.7.13
+  * accommodate root-run tests (used by Deb-O-Matic)
+
 2016-04-30 Martin A. Brown <martin@linux-ip.net>
   * bumping version to tldp-0.7.12
   * adding ChangeLog (this file)

--- a/NOTES.rst
+++ b/NOTES.rst
@@ -1,0 +1,18 @@
+Notes to future self
+++++++++++++++++++++
+
+To release a new version for different software consumers.
+
+  * commit all of the changes you want
+  * bump version in tldp/__init__.py
+  * adjust debian/changelog in accordance with Debian policy
+    N.B. the version must match what you put in tldp/__init__.py
+  * run 'python contrib/rpm-release.py' which will regenerate a
+    contrib/tldp.spec with the correct version
+  * commit debian/changelog tldp/__init__.py and contrib/tldp.spec
+  * tag the release
+  * run 'git push origin master --tags'
+  * run 'python setup.py sdist upload -r pypi'
+  * run 'bash contrib/debian-release.py' (on a Debian-ish box)
+
+

--- a/contrib/tldp.spec
+++ b/contrib/tldp.spec
@@ -1,8 +1,8 @@
 %define sourcename tldp
 %define name python-tldp
-%define version 0.7.12
-%define unmangled_version 0.7.12
-%define unmangled_version 0.7.12
+%define version 0.7.13
+%define unmangled_version 0.7.13
+%define unmangled_version 0.7.13
 %define release 1
 
 Summary: automatic publishing tool for DocBook, Linuxdoc and Asciidoc

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-tldp (0.7.12-1) unstable; urgency=low
+tldp (0.7.13-1) unstable; urgency=low
 
   * Initial release (Closes: #822181)
 
- -- Martin A. Brown <martin@linux-ip.net>  Wed, 27 Apr 2016 17:09:56 +0000
+ -- Martin A. Brown <martin@linux-ip.net>  Wed, 13 May 2016 16:28:22 +0000

--- a/debian/clean
+++ b/debian/clean
@@ -1,2 +1,4 @@
 tldp.egg-info/
 docs/_build/
+.coverage/
+.tox/

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -48,14 +48,18 @@ class Test_isreadablefile_and_friends(unittest.TestCase):
     def test_isreadablefile(self):
         f = ntf(prefix='readable-file')
         self.assertTrue(isreadablefile(f.name))
+        mode = os.stat(f.name).st_mode
         os.chmod(f.name, 0)
         self.assertFalse(isreadablefile(f.name))
+        os.chmod(f.name, mode)
 
     def test_arg_isreadablefile(self):
         f = ntf(prefix='readable-file')
         self.assertEqual(f.name, arg_isreadablefile(f.name))
+        mode = os.stat(f.name).st_mode
         os.chmod(f.name, 0)
         self.assertIsNone(arg_isreadablefile(f.name))
+        os.chmod(f.name, mode)
 
 
 class Test_arg_isstr(unittest.TestCase):
@@ -206,8 +210,10 @@ class Test_statfile(TestToolsFilesystem):
         f = ntf(dir=self.tempdir)
         omode = os.stat(self.tempdir).st_mode
         os.chmod(self.tempdir, 0)
-        with self.assertRaises(OSError):
+        with self.assertRaises(Exception) as ecm:
             statfile(f.name)
+        e = ecm.exception
+        self.assertIn(e.errno, (errno.EPERM, errno.EACCES))
         os.chmod(self.tempdir, omode)
         stbuf = statfile(f.name)
         self.assertIsInstance(stbuf, posix.stat_result)

--- a/tldp/__init__.py
+++ b/tldp/__init__.py
@@ -9,4 +9,4 @@ import tldp.outputs
 import tldp.sources
 import tldp.inventory
 
-VERSION = "0.7.12"
+VERSION = "0.7.13"

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34
+envlist = py27, py34, py35
+skip_missing_interpreters = True
 
 [testenv]
 commands = {envpython} setup.py test


### PR DESCRIPTION
The Debian project's Deb-O-Matic runs the build as root.  Since root (usually) has special ability to read any file at any time regardless of access permissions (mode), some tests failed.  Adding logic to address that and release.

Tested successfully now on travis, too.

-Martin
