### PR TITLE
fix guess(non-string) with Python 3.6

### DIFF
--- a/tldp/typeguesser.py
+++ b/tldp/typeguesser.py
@@ -57,7 +57,7 @@ def guess(fname):
     '''
     try:
         stem, ext = os.path.splitext(fname)
-    except AttributeError:
+    except (AttributeError, TypeError):
         return None
 
     if not ext:


### PR DESCRIPTION
The os.path.* functions now consistently raise TypeError rather than something
more random when called with inappropriate types.