### PR TITLE
support Python3.8+: fix import for MutableMapping and other minor fixes

### DIFF
--- a/tldp/config.py
+++ b/tldp/config.py
@@ -8,7 +8,6 @@ from __future__ import unicode_literals
 
 import os
 import argparse
-import copy as _copy
 
 import logging
 
@@ -30,7 +29,7 @@ class DirectoriesExist(argparse._AppendAction):
             message = message % (values, option_string)
             logger.critical(message)
             raise ValueError(message)
-        items = _copy.copy(argparse._ensure_value(namespace, self.dest, []))
+        items = getattr(namespace, self.dest, [])
         items.append(values)
         setattr(namespace, self.dest, items)
 

--- a/tldp/ldpcollection.py
+++ b/tldp/ldpcollection.py
@@ -5,10 +5,15 @@
 
 from __future__ import absolute_import, division, print_function
 
-import collections
+import sys
+
+if sys.version_info[:2] >= (3, 8):  # pragma: no cover
+    from collections.abc import MutableMapping
+else:  # pragma: no cover
+    from collections import MutableMapping
 
 
-class LDPDocumentCollection(collections.MutableMapping):
+class LDPDocumentCollection(MutableMapping):
     '''a dict-like container for DocumentCollection objects
 
     Intended to be subclassed.

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35
+envlist = py39, py310
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
In the Python3.8+ series, the `collections` module moved `MutableMapping` from `collections` to `collections.abc`.

A private method in `argparse` was removed, so use similar technique as the authors of `argparse` to accomplish the desired behaviour.

Cease supporting the (by now) EOL Python2.x series.